### PR TITLE
refactor: switch from tun-rs to quincy-tun

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,27 +622,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "c2rust-bitfields"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b9a85391b09c224053f3c45344f0639822e641f9d2b4f351bb3152600742d"
-dependencies = [
- "c2rust-bitfields-derive",
-]
-
-[[package]]
-name = "c2rust-bitfields-derive"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "153187c06ed005d5cb75ed9f0a2f274836f54f6b2efdc1f45136e728764875f9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-ident",
-]
-
-[[package]]
 name = "calloop"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1248,7 +1227,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.2+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -4006,6 +3985,7 @@ dependencies = [
  "jemallocator",
  "libc",
  "nu-ansi-term",
+ "quincy-tun",
  "quinn",
  "rand_core 0.6.4",
  "reishi-quinn",
@@ -4020,7 +4000,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "tun-rs",
  "wintun-bindings",
  "zeroize",
 ]
@@ -4113,6 +4092,31 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-test",
+]
+
+[[package]]
+name = "quincy-tun"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acfb32d756918d88d8704ab0978c3e1558b5156cc8e477fc2360784f724220dd"
+dependencies = [
+ "blocking",
+ "byteorder",
+ "bytes",
+ "encoding_rs",
+ "getifaddrs",
+ "ipnet",
+ "libc",
+ "libloading 0.9.0",
+ "log",
+ "netconfig-rs",
+ "nix 0.31.3",
+ "route_manager",
+ "scopeguard",
+ "tokio",
+ "widestring",
+ "windows-sys 0.61.2",
+ "winreg 0.56.0",
 ]
 
 [[package]]
@@ -5628,32 +5632,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tun-rs"
-version = "2.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aed038a26d2b6a7906a62b3d0c42fb77541b0a695b9c2b9489a0c25c093ce8b"
-dependencies = [
- "blocking",
- "byteorder",
- "bytes",
- "c2rust-bitfields",
- "encoding_rs",
- "getifaddrs",
- "ipnet",
- "libc",
- "libloading 0.9.0",
- "log",
- "netconfig-rs",
- "nix 0.31.3",
- "route_manager",
- "scopeguard",
- "tokio",
- "widestring",
- "windows-sys 0.61.2",
- "winreg",
-]
-
-[[package]]
 name = "two-face"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6913,6 +6891,16 @@ checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Jakub Kubík <jakub.kubik.it@protonmail.com>"]
 license = "AGPL-3.0-or-later"
 readme = "README.md"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 homepage = "https://github.com/quincy-rs/quincy"
 repository = "https://github.com/quincy-rs/quincy"
 keywords = ["vpn", "quic", "tunnel", "networking", "tokio"]
@@ -29,7 +29,7 @@ quinn = { version = "^0.11.8", default-features = false, features = [
 ] }
 
 # Interfaces and networking
-tun-rs = { version = "=2.8.2", features = ["async_tokio"] } # pinned audited version
+quincy-tun = "^1.0.0"
 socket2 = { version = "^0.6.0", features = ["all"] }
 libc = "^0.2"
 bytes = "^1.11"

--- a/quincy-client/src/bin/main.rs
+++ b/quincy-client/src/bin/main.rs
@@ -4,7 +4,7 @@ use std::process::exit;
 use clap::Parser;
 use quincy::Result;
 use quincy::config::{ClientConfig, FromPath};
-use quincy::network::interface::tun_rs::TunRsInterface;
+use quincy::network::interface::quincy_tun::QuincyTunInterface;
 use quincy::utils::tracing::log_subscriber;
 use quincy_client::client::QuincyClient;
 use tracing::error;
@@ -40,6 +40,6 @@ async fn run_client() -> Result<()> {
     tracing::subscriber::set_global_default(log_subscriber(&config.log.level))?;
 
     let mut client = QuincyClient::new(config);
-    client.start::<TunRsInterface>().await?;
+    client.start::<QuincyTunInterface>().await?;
     client.wait_for_shutdown().await
 }

--- a/quincy-client/src/client.rs
+++ b/quincy-client/src/client.rs
@@ -12,7 +12,7 @@ use quincy::constants::QUINN_RUNTIME;
 use quincy::error::ConfigError;
 use quincy::ip_assignment;
 #[cfg(unix)]
-use quincy::network::interface::tun_rs::TunRsInterface;
+use quincy::network::interface::quincy_tun::QuincyTunInterface;
 use quincy::network::interface::{Interface, InterfaceIO};
 use quincy::network::socket::bind_socket;
 use quincy::{QuincyError, Result};
@@ -134,14 +134,14 @@ impl QuincyClient {
     /// # Safety
     ///
     /// `create_tun_fd` must return a valid TUN file descriptor compatible with
-    /// `tun-rs`. The returned fd must not be owned by any platform SDK object
+    /// `quincy-tun`. The returned fd must not be owned by any platform SDK object
     /// after it is returned to Quincy.
     #[cfg(unix)]
     pub async unsafe fn start_with_tun_fd<F>(&mut self, create_tun_fd: F) -> Result<()>
     where
         F: FnOnce(ClientInterfaceConfig) -> Result<OwnedFd>,
     {
-        self.start_with_interface::<TunRsInterface, _>(move |interface_config| {
+        self.start_with_interface::<QuincyTunInterface, _>(move |interface_config| {
             let mtu = interface_config.mtu;
             let tunnel_gateway = interface_config.tunnel_gateway;
             let remote_address = Some(interface_config.remote_address);
@@ -149,8 +149,8 @@ impl QuincyClient {
 
             // SAFETY: `create_tun_fd` runs inside this unsafe API and must
             // return an exclusively-owned TUN fd that satisfies
-            // `TunRsInterface::from_fd`'s safety contract.
-            let interface = unsafe { TunRsInterface::from_fd(fd, mtu, tunnel_gateway)? };
+            // `QuincyTunInterface::from_fd`'s safety contract.
+            let interface = unsafe { QuincyTunInterface::from_fd(fd, mtu, tunnel_gateway)? };
 
             Ok(Interface::from_io(interface, None, None, remote_address))
         })

--- a/quincy-gui/src/bin/client_daemon.rs
+++ b/quincy-gui/src/bin/client_daemon.rs
@@ -2,7 +2,7 @@
 
 use clap::Parser;
 use quincy::config::{ClientConfig, FromPath};
-use quincy::network::interface::tun_rs::TunRsInterface;
+use quincy::network::interface::quincy_tun::QuincyTunInterface;
 use quincy::{QuincyError, Result};
 use quincy_client::client::QuincyClient;
 use quincy_gui::gui::GuiError;
@@ -85,7 +85,7 @@ impl ClientDaemon {
         let mut client = QuincyClient::new(config);
 
         // Start the client in a separate task so we can listen for cancellation
-        let start_future = client.start::<TunRsInterface>();
+        let start_future = client.start::<QuincyTunInterface>();
 
         tokio::select! {
             result = start_future => {

--- a/quincy-gui/src/gui/utils.rs
+++ b/quincy-gui/src/gui/utils.rs
@@ -74,10 +74,10 @@ pub fn expand_path(path: &Path) -> PathBuf {
     let path_str = path.to_string_lossy();
 
     #[cfg(unix)]
-    if path_str.starts_with("~/") {
-        if let Ok(home) = env::var("HOME") {
-            return PathBuf::from(path_str.replacen("~", &home, 1));
-        }
+    if path_str.starts_with("~/")
+        && let Ok(home) = env::var("HOME")
+    {
+        return PathBuf::from(path_str.replacen("~", &home, 1));
     }
 
     #[cfg(windows)]

--- a/quincy-gui/src/ipc.rs
+++ b/quincy-gui/src/ipc.rs
@@ -73,10 +73,10 @@ impl IpcServer {
         #[cfg(unix)]
         {
             // Ensure the parent directory exists
-            if let Some(parent) = socket_path.parent() {
-                if !parent.exists() {
-                    fs::create_dir_all(parent)?;
-                }
+            if let Some(parent) = socket_path.parent()
+                && !parent.exists()
+            {
+                fs::create_dir_all(parent)?;
             }
 
             // Remove existing socket file if it exists

--- a/quincy-server/src/main.rs
+++ b/quincy-server/src/main.rs
@@ -4,7 +4,7 @@ use std::process::exit;
 use clap::Parser;
 use quincy::Result;
 use quincy::config::{FromPath, ServerConfig};
-use quincy::network::interface::tun_rs::TunRsInterface;
+use quincy::network::interface::quincy_tun::QuincyTunInterface;
 use quincy::utils::tracing::log_subscriber;
 use quincy_server::server::QuincyServer;
 use tracing::error;
@@ -40,5 +40,5 @@ async fn run_server() -> Result<()> {
     tracing::subscriber::set_global_default(log_subscriber(&config.log.level))?;
 
     let server = QuincyServer::new(config)?;
-    server.run::<TunRsInterface>().await
+    server.run::<QuincyTunInterface>().await
 }

--- a/quincy/Cargo.toml
+++ b/quincy/Cargo.toml
@@ -26,7 +26,7 @@ jemalloc = ["jemallocator"]
 quinn = { workspace = true }
 
 # Interfaces and networking
-tun-rs = { workspace = true }
+quincy-tun = { workspace = true }
 socket2 = { workspace = true }
 libc = { workspace = true }
 bytes = { workspace = true }

--- a/quincy/src/config.rs
+++ b/quincy/src/config.rs
@@ -348,11 +348,11 @@ impl fmt::Display for Bandwidth {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let bits_per_second = self.0 * 8;
 
-        if bits_per_second > 0 && bits_per_second % 1_000_000_000 == 0 {
+        if bits_per_second > 0 && bits_per_second.is_multiple_of(1_000_000_000) {
             write!(f, "{} gbps", bits_per_second / 1_000_000_000)
-        } else if bits_per_second > 0 && bits_per_second % 1_000_000 == 0 {
+        } else if bits_per_second > 0 && bits_per_second.is_multiple_of(1_000_000) {
             write!(f, "{} mbps", bits_per_second / 1_000_000)
-        } else if bits_per_second > 0 && bits_per_second % 1_000 == 0 {
+        } else if bits_per_second > 0 && bits_per_second.is_multiple_of(1_000) {
             write!(f, "{} kbps", bits_per_second / 1_000)
         } else {
             write!(f, "{} bps", bits_per_second)

--- a/quincy/src/ip_assignment.rs
+++ b/quincy/src/ip_assignment.rs
@@ -114,10 +114,10 @@ fn validate_assignment_address(ipnet: IpNet) -> Result<()> {
         return Err(AuthError::IpAssignmentFailed.into());
     }
 
-    if let IpAddr::V4(v4) = addr {
-        if v4.is_broadcast() {
-            return Err(AuthError::IpAssignmentFailed.into());
-        }
+    if let IpAddr::V4(v4) = addr
+        && v4.is_broadcast()
+    {
+        return Err(AuthError::IpAssignmentFailed.into());
     }
 
     if ipnet.prefix_len() == 0 {

--- a/quincy/src/network/interface/mod.rs
+++ b/quincy/src/network/interface/mod.rs
@@ -1,6 +1,6 @@
 #![allow(async_fn_in_trait)]
 
-pub mod tun_rs;
+pub mod quincy_tun;
 
 use crate::Result;
 use crate::network::packet::Packet;
@@ -50,13 +50,13 @@ impl<I: InterfaceIO> RouteGuard<I> {
 
 impl<I: InterfaceIO> Drop for RouteGuard<I> {
     fn drop(&mut self) {
-        if let Some(exclusion) = &self.exclusion {
-            if let Err(e) = self.inner.remove_exclusion_route(exclusion) {
-                error!(
-                    "Failed to remove exclusion route for {}: {e}",
-                    exclusion.destination
-                );
-            }
+        if let Some(exclusion) = &self.exclusion
+            && let Err(e) = self.inner.remove_exclusion_route(exclusion)
+        {
+            error!(
+                "Failed to remove exclusion route for {}: {e}",
+                exclusion.destination
+            );
         }
     }
 }
@@ -90,10 +90,10 @@ impl<I: InterfaceIO> Drop for DnsGuard<I> {
     fn drop(&mut self) {
         let dns_servers = self.dns_servers.as_deref().unwrap_or_default();
 
-        if !dns_servers.is_empty() {
-            if let Err(e) = self.inner.cleanup_dns(dns_servers) {
-                error!("Failed to cleanup DNS servers: {e}");
-            }
+        if !dns_servers.is_empty()
+            && let Err(e) = self.inner.cleanup_dns(dns_servers)
+        {
+            error!("Failed to cleanup DNS servers: {e}");
         }
     }
 }

--- a/quincy/src/network/interface/quincy_tun.rs
+++ b/quincy/src/network/interface/quincy_tun.rs
@@ -7,6 +7,7 @@ use crate::network::packet::Packet;
 use crate::network::route::{InstalledExclusionRoute, add_routes};
 use bytes::BytesMut;
 use ipnet::IpNet;
+use quincy_tun::{AsyncDevice, DeviceBuilder, ToIpv4Address};
 use std::net::IpAddr;
 #[cfg(unix)]
 use std::os::fd::{IntoRawFd, OwnedFd};
@@ -16,9 +17,8 @@ use tokio::sync::Mutex;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
-use tun_rs::{AsyncDevice, DeviceBuilder, ToIpv4Address};
 
-pub struct TunRsInterface {
+pub struct QuincyTunInterface {
     inner: Arc<AsyncDevice>,
     reader_channel: Mutex<Receiver<Packet>>,
     writer_channel: Sender<Packet>,
@@ -30,7 +30,7 @@ pub struct TunRsInterface {
     disable_on_teardown: bool,
 }
 
-impl TunRsInterface {
+impl QuincyTunInterface {
     fn from_async_device(
         interface: AsyncDevice,
         mtu: u16,
@@ -68,13 +68,13 @@ impl TunRsInterface {
     ///
     /// # Safety
     ///
-    /// `fd` must be a valid TUN file descriptor compatible with `tun-rs`, and
+    /// `fd` must be a valid TUN file descriptor compatible with `quincy-tun`, and
     /// must not be owned by any other platform object after ownership is passed
     /// to this function.
     #[cfg(unix)]
     pub unsafe fn from_fd(fd: OwnedFd, mtu: u16, tunnel_gateway: Option<IpAddr>) -> Result<Self> {
         // SAFETY: the caller guarantees that `fd` is a valid, exclusively-owned
-        // TUN fd. `into_raw_fd` transfers that ownership to `tun-rs`, which
+        // TUN fd. `into_raw_fd` transfers that ownership to `quincy-tun`, which
         // wraps the fd before fallible async registration and closes it on
         // either construction failure or eventual device drop.
         let interface = unsafe { AsyncDevice::from_fd(fd.into_raw_fd()) }
@@ -89,7 +89,7 @@ impl TunRsInterface {
     }
 }
 
-impl InterfaceIO for TunRsInterface {
+impl InterfaceIO for QuincyTunInterface {
     fn create_interface(
         interface_address: IpNet,
         mtu: u16,
@@ -295,7 +295,7 @@ impl InterfaceIO for TunRsInterface {
     }
 }
 
-impl TunRsInterface {
+impl QuincyTunInterface {
     /// Idempotent teardown shared by `InterfaceIO::down()` and `Drop`: aborts
     /// the I/O tasks and disables the TUN device. Subsequent calls are no-ops.
     fn teardown(&self) -> Result<()> {
@@ -325,7 +325,7 @@ impl TunRsInterface {
     }
 }
 
-impl Drop for TunRsInterface {
+impl Drop for QuincyTunInterface {
     fn drop(&mut self) {
         if let Err(e) = self.teardown() {
             warn!("TUN teardown during drop failed: {e}");
@@ -407,8 +407,8 @@ fn reader_task(
     reader_channel_tx: Sender<Packet>,
     mtu: usize,
 ) -> JoinHandle<Result<()>> {
+    use quincy_tun::{IDEAL_BATCH_SIZE, VIRTIO_NET_HDR_LEN};
     use std::iter;
-    use tun_rs::{IDEAL_BATCH_SIZE, VIRTIO_NET_HDR_LEN};
 
     let batch_size = (u16::MAX as usize / mtu).min(IDEAL_BATCH_SIZE);
 
@@ -483,7 +483,7 @@ fn writer_task(
     mut writer_channel_rx: Receiver<Packet>,
     mtu: usize,
 ) -> JoinHandle<Result<()>> {
-    use tun_rs::{GROTable, IDEAL_BATCH_SIZE, VIRTIO_NET_HDR_LEN};
+    use quincy_tun::{GROTable, IDEAL_BATCH_SIZE, VIRTIO_NET_HDR_LEN};
 
     let batch_size = (u16::MAX as usize / mtu).min(IDEAL_BATCH_SIZE);
     let send_buf_size = VIRTIO_NET_HDR_LEN * batch_size + batch_size * mtu;
@@ -555,7 +555,7 @@ mod tests {
         );
 
         // SAFETY: this only queries whether the captured descriptor number still
-        // refers to an open fd after ownership moved into `TunRsInterface::from_fd`.
+        // refers to an open fd after ownership moved into `QuincyTunInterface::from_fd`.
         let flags = unsafe { libc::fcntl(raw_fd, libc::F_GETFD) };
         let errno = std::io::Error::last_os_error().raw_os_error();
 
@@ -571,7 +571,7 @@ mod tests {
 
         // SAFETY: this intentionally passes a non-TUN fd to exercise the
         // rejection path after ownership has moved into `from_fd`.
-        let result = unsafe { TunRsInterface::from_fd(fd, 1500, None) };
+        let result = unsafe { QuincyTunInterface::from_fd(fd, 1500, None) };
         assert!(result.is_err());
 
         assert_fd_closed(raw_fd);

--- a/quincy/src/network/route/posix.rs
+++ b/quincy/src/network/route/posix.rs
@@ -80,13 +80,13 @@ pub fn add_routes(
 
     for network in effective_networks {
         if let Err(add_err) = add_route(network, gateway) {
-            if let Some(ref token) = exclusion {
-                if let Err(rm_err) = remove_exclusion_route(token) {
-                    warn!(
-                        "failed to roll back exclusion route for {}: {rm_err}",
-                        token.destination
-                    );
-                }
+            if let Some(ref token) = exclusion
+                && let Err(rm_err) = remove_exclusion_route(token)
+            {
+                warn!(
+                    "failed to roll back exclusion route for {}: {rm_err}",
+                    token.destination
+                );
             }
             return Err(add_err);
         }
@@ -734,13 +734,13 @@ fn parse_linux_route_get(output: &str, address: &IpAddr) -> Result<NextHop> {
     // route installed via an unreachable/blackhole/prohibit/throw route
     // would either drop the server's traffic or fall through to a later
     // lookup that may now be captured by the tunnel, so we refuse outright.
-    if let Some(first) = tokens.first() {
-        if matches!(*first, "unreachable" | "blackhole" | "prohibit" | "throw") {
-            return Err(RouteError::NotFound {
-                destination: address.to_string(),
-            }
-            .into());
+    if let Some(first) = tokens.first()
+        && matches!(*first, "unreachable" | "blackhole" | "prohibit" | "throw")
+    {
+        return Err(RouteError::NotFound {
+            destination: address.to_string(),
         }
+        .into());
     }
 
     let interface = find_token_value(&tokens, "dev")

--- a/quincy/src/network/socket.rs
+++ b/quincy/src/network/socket.rs
@@ -96,10 +96,10 @@ fn try_set_buffer_size(
     label: &str,
 ) -> Result<()> {
     if try_set_fn(socket, requested, set_fn, label)? {
-        if let Ok(actual) = get_fn(socket) {
-            if actual < requested {
-                warn!("Unable to set desired {label}. Desired: {requested}, Actual: {actual}",);
-            }
+        if let Ok(actual) = get_fn(socket)
+            && actual < requested
+        {
+            warn!("Unable to set desired {label}. Desired: {requested}, Actual: {actual}",);
         }
         return Ok(());
     }


### PR DESCRIPTION
This PR switches Quincy from `tun-rs` to vendored and minimized `quincy-tun`.