### PR TITLE
fix: address TUN offload error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -170,7 +170,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1310,7 +1310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3112,7 +3112,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4088,9 +4088,9 @@ dependencies = [
 
 [[package]]
 name = "quincy-tun"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acfb32d756918d88d8704ab0978c3e1558b5156cc8e477fc2360784f724220dd"
+checksum = "c2c68d2f6e080681bb9c3b7b2412fc4739139a86dae6a1d7d56ae6a627e1ddfe"
 dependencies = [
  "blocking",
  "byteorder",
@@ -4105,6 +4105,7 @@ dependencies = [
  "nix 0.31.3",
  "route_manager",
  "scopeguard",
+ "thiserror 2.0.18",
  "tokio",
  "widestring",
  "windows-sys 0.61.2",
@@ -4625,7 +4626,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4691,7 +4692,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5070,7 +5071,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5239,7 +5240,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5669,7 +5670,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6309,7 +6310,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6847,7 +6848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ quinn = { version = "^0.11.8", default-features = false, features = [
 ] }
 
 # Interfaces and networking
-quincy-tun = "^1.0.0"
+quincy-tun = "^2.0.0"
 socket2 = { version = "^0.6.0", features = ["all"] }
 libc = "^0.2"
 bytes = "^1.11"

--- a/quincy/src/error.rs
+++ b/quincy/src/error.rs
@@ -64,6 +64,10 @@ pub enum QuincyError {
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 
+    /// TUN operations that can fail during device I/O or packet offload processing
+    #[error("TUN error: {0}")]
+    Tun(#[from] quincy_tun::Error),
+
     /// Generic system errors for unrecoverable conditions
     #[error("System error: {message}")]
     System { message: String },

--- a/quincy/src/network/interface/quincy_tun.rs
+++ b/quincy/src/network/interface/quincy_tun.rs
@@ -407,7 +407,7 @@ fn reader_task(
     reader_channel_tx: Sender<Packet>,
     mtu: usize,
 ) -> JoinHandle<Result<()>> {
-    use quincy_tun::{IDEAL_BATCH_SIZE, VIRTIO_NET_HDR_LEN};
+    use quincy_tun::{Error as TunError, IDEAL_BATCH_SIZE, OffloadError, VIRTIO_NET_HDR_LEN};
     use std::iter;
 
     let batch_size = (u16::MAX as usize / mtu).min(IDEAL_BATCH_SIZE);
@@ -434,9 +434,9 @@ fn reader_task(
 
             let num_packets = match num_packets {
                 Ok(num_packets) => Ok(num_packets),
-                // gso_split returns ErrTooManySegments after all batch_size output
-                // slots have been filled; the first batch_size segments are valid.
-                Err(e) if e.to_string() == "ErrTooManySegments" => Ok(batch_size),
+                Err(TunError::Offload(OffloadError::TooManyGsoSegments { completed_segments })) => {
+                    Ok(completed_segments)
+                }
                 Err(e) => Err(e),
             }
             .inspect_err(|e| error!("failed to receive packets from interface: {e}"))?;


### PR DESCRIPTION
This PR fixes an issue where GSO segmentation errors were incorrectly passed from quincy-tun, resulting in an unrecoverable error where previously this was a completely recoverable condition.

Closes #218 